### PR TITLE
Fix error caused by the removal of `#check_if_write_query` at activerecord 8.1.0.rc1

### DIFF
--- a/lib/active_record/connection_adapters/redshift_8_0_adapter.rb
+++ b/lib/active_record/connection_adapters/redshift_8_0_adapter.rb
@@ -510,7 +510,9 @@ module ActiveRecord
       FEATURE_NOT_SUPPORTED = '0A000' # :nodoc:
 
       def execute_and_clear(sql, name, binds, prepare: false, async: false, allow_retry: false, materialize_transactions: true)
-        check_if_write_query(sql)
+        if preventing_writes? && write_query?(sql)
+          raise ActiveRecord::ReadOnlyError, "Write query attempted while in readonly mode: #{sql}"
+        end
 
         if !prepare || binds.nil? || binds.empty?
           result = exec_no_cache(sql, name, binds, async: async, allow_retry: allow_retry, materialize_transactions: materialize_transactions)


### PR DESCRIPTION
There’s no link from [RubyGems](https://rubygems.org/gems/activerecord-redshift-adapter) to this repository yet, so I couldn’t be completely sure whether this is the correct repository for the *activerecord-redshift-adapter* gem. My apologies if I got it wrong.

I’ve been using this gem with activerecord 8.0.3 without issues, but when I tried migrating to the recently released activerecord 8.1.0.rc1, I encountered an error and it didn’t work as expected. Since it looks like GitHub Issues are intentionally disabled in this repository, I’m submitting this report in the form of a pull request instead.

```
NoMethodError:
  undefined method 'check_if_write_query' for an instance of ActiveRecord::ConnectionAdapters::RedshiftAdapter
.../vendor/bundle/ruby/3.4.0/gems/activerecord-redshift-adapter-8.0.0/lib/active_record/connection_adapters/redshift_8_0_adapter.rb:513:in 'ActiveRecord::ConnectionAdapters::RedshiftAdapter#execute_and_clear'
```

It seems that the issue is caused by the removal of the `#check_if_write_query` method, which this gem relies on, in activerecord 8.1.0.rc1. A similar method, `#ensure_writes_are_allowed`, has been introduced as a replacement, but its behavior is not identical to `#check_if_write_query`. Moreover, using this new method would make it somewhat cumbersome to support both ActiveRecord 8.0 and 8.1 simultaneously.

- https://github.com/rails/rails/commit/07854a55607f845a72c4a9d43d4bedfe954d038c

For that reason, as a solution, I tried simply inlining the original implementation of `#check_if_write_query`.
