### PR TITLE
missing method `check_if_write_query`

### DIFF
--- a/lib/active_record/connection_adapters/redshift_8_0_adapter.rb
+++ b/lib/active_record/connection_adapters/redshift_8_0_adapter.rb
@@ -360,6 +360,16 @@ module ActiveRecord
         end
       end
 
+      # Rails 8.1 deprecated AbstractAdapter#check_if_write_query
+      # Implement it here for compatibility if it doesn't exist in the parent class
+      unless AbstractAdapter.method_defined?(:check_if_write_query)
+        def check_if_write_query(sql)
+          return unless preventing_writes? && write_query?(sql)
+
+          raise ActiveRecord::ReadOnlyError, "Write query attempted while in readonly mode: #{sql}"
+        end
+      end
+
       class << self
         def initialize_type_map(m)
           # :nodoc:

--- a/lib/active_record/connection_adapters/redshift_8_0_adapter.rb
+++ b/lib/active_record/connection_adapters/redshift_8_0_adapter.rb
@@ -90,6 +90,25 @@ module ActiveRecord
       include Redshift::SchemaStatements
       include Redshift::DatabaseStatements
 
+      # Rails 8.1+ compatibility: mark_transaction_written_if_write was removed
+      # and replaced with mark_transaction_written (no parameters).
+      # This method provides backward compatibility for our adapter.
+      if ActiveRecord.version >= Gem::Version.new('8.1.0')
+        def mark_transaction_written_if_write(sql) # :nodoc:
+          transaction = current_transaction
+          if transaction.open? && write_query?(sql)
+            mark_transaction_written
+          end
+        end
+      end
+
+      # Compatibility: in_transaction? is defined in PostgreSQLAdapter but not in AbstractAdapter.
+      # Since RedshiftAdapter inherits from AbstractAdapter (not PostgreSQLAdapter),
+      # we need to provide this method. It's used for prepared statement cache handling.
+      def in_transaction? # :nodoc:
+        open_transactions > 0
+      end
+
       def schema_creation # :nodoc:
         Redshift::SchemaCreation.new self
       end


### PR DESCRIPTION
Hi @januszm!

Today I tried to update Rails from 8.0.x to 8.1.2 and it failed with this error message:
`NoMethodError: undefined method 'check_if_write_query' for an instance of ActiveRecord::ConnectionAdapters::RedshiftAdapter`. Turns out, ActiveRecord's AbstractAdapter doesn't have this method anymore since 8.1.0-rc1: https://github.com/rails/rails/blob/v8.1.0.rc1/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb

I asked Gh Copilot to vibe-code a fix, and for some reason it decided to include the fix to 7.x adapters as well ¯\_(ツ)_/¯ 
Anyway, please let me know if this is the way you'd suggest fixing it, or if you'd prefer a standalone adapter for 8.1 specifically? I'll manually clean up the code in the branch once I know the preferred option. I'll test if the fix works tomorrow.